### PR TITLE
nginx: use alpine base image

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,7 +1,7 @@
-FROM nginx:1.19
+FROM nginx:1.21.6-alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY default.conf.template /etc/nginx/templates/default.conf.template
 COPY nginx-override.conf /etc/nginx/conf.d/letter-avatars-http-ctx.conf
 
-RUN adduser --uid 9001 --gecos 'Stable nginx UID' --home /usr/share/empty --no-create-home --disabled-password --disabled-login nginx-for-realz
+RUN adduser --uid 9001 --gecos 'Stable nginx UID' --home /usr/share/empty --no-create-home --disabled-password nginx-for-realz


### PR DESCRIPTION
This change is because of https://security-tracker.debian.org/tracker/CVE-2021-45960 which hasn't been fixed in the latest nginx debian image.