### PR TITLE
fix COPY of lib directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,12 +45,11 @@ COPY fonts/Roboto-Medium \
         Gemfile \
         Gemfile.lock \
         config.ru \
-        lib \
         unicorn.conf.rb \
     /var/www/letter-avatars/
+COPY lib/ /var/www/letter-avatars/lib/
 COPY as-web entrypoint /usr/local/sbin/
-
-ADD policy.xml   /usr/local/etc/ImageMagick-7/
+COPY policy.xml   /usr/local/etc/ImageMagick-7/
 
 RUN adduser \
       --shell /bin/bash \


### PR DESCRIPTION
We must specify a seperate COPY command for the application files to end up in the /var/www/letter-avatars/lib directory. Otherwise, these files end up in the root of the directory and config.ru cannot require them.

Also made usage of COPY consistent rather than a mix of ADD and COPY.

Follow-up to 6e3cb40.