### PR TITLE
docker: do not install development deps in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
   ruby-dev
 cd /var/www/letter-avatars
 bundle config set deployment true
+bundle config set without    development:test
 bundle install --verbose
 EOF
 


### PR DESCRIPTION
This is a public repo so my usual colourful commentary has been restrained.

They apparently use colons as separators.
https://bundler.io/v1.12/man/bundle-config.1.html#LIST-OF-AVAILABLE-KEYS

We do not have a `development` group configured in this particular `Gemfile`, though I think it is commonly used amongst Ruby developers.  Many of our internal source repos include this gem group.  I have included it here to ensure these gems, if any are added in the future, are also eradicated from the OCI image.

254MB &rarr; 236MB